### PR TITLE
Update vadc email

### DIFF
--- a/config/gen3/navigation.json
+++ b/config/gen3/navigation.json
@@ -39,7 +39,7 @@
         "name": "Help and Guidance"
       },
       {
-        "href": "mailto:vadc@lists.uchicago.edu",
+        "href": "mailto:vadc-support@gen3.org",
         "name": "Email Support"
       }
     ],

--- a/src/lib/AnalysisApps/SharedUtils/TeamProject/TeamProjectModal/TeamProjectModal.tsx
+++ b/src/lib/AnalysisApps/SharedUtils/TeamProject/TeamProjectModal/TeamProjectModal.tsx
@@ -106,7 +106,7 @@ const TeamProjectModal: React.FC<TeamProjectModalProps> = ({
       >
         <div className="team-project-modal_modal-description">
           Please reach out to{' '}
-          <a href="mailto:vadc@lists.uchicago.edu">vadc@lists.uchicago.edu</a>{' '}
+          <a href="mailto:vadc-support@gen3.org">vadc-support@gen3.org</a>{' '}
           to gain access to the system
         </div>
         <Button key="submit" onClick={redirectToHomepage}>


### PR DESCRIPTION
https://ctds-planx.atlassian.net/browse/VADC-1685
all email references that currently are [vadc@lists.uchicago.edu](mailto:vadc@lists.uchicago.edu) → change to [vadc-support@gen3.org](mailto:vadc-support@gen3.org)
For Feb 17 release